### PR TITLE
New `apply_if_some...` functions, Doc updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apply_if"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT OR Apache-2.0"
 description = "Conditionally apply a closure to an item or return it"
 repository = "https://github.com/bavalpey/apply_if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+derive_builder = "0.20"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,123 @@
-# ApplyIf
+# ApplyIf: Seamless Conditionals for Builder Chains
+
 [![CI](https://github.com/bavalpey/apply_if/actions/workflows/tests.yml/badge.svg)](https://github.com/bavalpey/apply_if/actions/workflows/tests.yml)
 
-ApplyIf supplies a trait with two methods: ``apply_if(cond, closure)`` and
-``apply_if_mut(cond, closure)``. These apply the given closure
-on an instance if `cond` is true, returning the original instance otherwise
-(or a reference in case of ``apply_if_mut``).  
+This crates provides the functions `apply_if` and `apply_if_some` for consuming
+builders, as well as `apply_if_mut` and `apply_if_some_mut` for mutable builder
+chains. They allow us to conditionally invoke builder functions while keeping
+the nice chaining syntax.
 
-Very useful for both the immutable and the mutable builder patterns
-when you want to keep the nice ``.builder1().builder2()`` chain, and not interrupt
-it with if-else blocks.  
+# Examples
 
-Comes with a blanket implementation for all types, where ``apply_if`` is only
-implemented for sized types.
+This example uses the [`derive_builder`](https://crates.io/crates/derive_builder)
+crate to derive a builder and then uses the `apply_if_...` functions to show
+how to conditionally invoke builder functions without breaking the chain.
+
+## Mutable Builders
+
+This example uses a mutable builder pattern, which is why `apply_if_mut`
+and `apply_if_some_mut` are used.
+
+```rust
+extern crate derive_builder;
+use derive_builder::Builder;
+use apply_if::ApplyIf;
+
+#[derive(Debug,PartialEq,Builder)]
+struct Value{
+  #[builder(default = 123)]
+  first: i32,
+  #[builder(default = 42.)]
+  second: f32,
+}
+
+fn main () {
+    // apply_if_mut only applies the function
+    // if the condition is true
+    let value1 = ValueBuilder::default()
+        .apply_if_mut(true, |builder| builder.first(100))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value1, Value{first: 100, second: 1.337});
+
+    let value2 = ValueBuilder::default()
+        .apply_if_mut(false, |builder| builder.first(100))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value2, Value{first: 123, second: 1.337});
+
+    // apply_if_some_mut only applies the function
+    // if the optional contains a value
+    
+    let value3 = ValueBuilder::default()
+        .apply_if_some_mut(Some(100), |builder,val| builder.first(val))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value3, Value{first: 100, second: 1.337});
+
+    let value3 = ValueBuilder::default()
+        .apply_if_some_mut(None, |builder,val| builder.first(val))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value3, Value{first: 123, second: 1.337});
+}
+```
+
+# Immutable Builders
+
+This example uses a consuming builder pattern, which is why `apply_if`
+and `apply_if_some` are used.
+
+```rust
+extern crate derive_builder;
+use derive_builder::Builder;
+use apply_if::ApplyIf;
+
+#[derive(Debug,PartialEq,Builder)]
+#[builder(pattern = "immutable")]
+struct Value{
+  #[builder(default = 123)]
+  first: i32,
+  #[builder(default = 42.)]
+  second: f32,
+}
+
+fn main () {
+    // apply_if_mut only applies the function
+    // if the condition is true
+    let value1 = ValueBuilder::default()
+        .apply_if(true, |builder| builder.first(100))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value1, Value{first: 100, second: 1.337});
+
+    let value2 = ValueBuilder::default()
+        .apply_if(false, |builder| builder.first(100))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value2, Value{first: 123, second: 1.337});
+
+    // apply_if_some_mut only applies the function
+    // if the optional contains a value
+    
+    let value3 = ValueBuilder::default()
+        .apply_if_some(Some(100), |builder,val| builder.first(val))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value3, Value{first: 100, second: 1.337});
+
+    let value3 = ValueBuilder::default()
+        .apply_if_some(None, |builder,val| builder.first(val))
+        .second(1.337)
+        .build()
+        .unwrap();
+    assert_eq!(value3, Value{first: 123, second: 1.337});
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/bavalpey/apply_if/actions/workflows/tests.yml/badge.svg)](https://github.com/bavalpey/apply_if/actions/workflows/tests.yml)
 
-This crates provides the functions `apply_if` and `apply_if_some` for consuming
+This crate provides the functions `apply_if` and `apply_if_some` for consuming
 builders, as well as `apply_if_mut` and `apply_if_some_mut` for mutable builder
 chains. They allow us to conditionally invoke builder functions while keeping
 the nice chaining syntax.

--- a/README.md
+++ b/README.md
@@ -34,36 +34,36 @@ struct Value{
 fn main () {
     // apply_if_mut only applies the function
     // if the condition is true
-    let value1 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if_mut(true, |builder| builder.first(100))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value1, Value{first: 100, second: 1.337});
+    assert_eq!(value, Value{first: 100, second: 1.337});
 
-    let value2 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if_mut(false, |builder| builder.first(100))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value2, Value{first: 123, second: 1.337});
+    assert_eq!(value, Value{first: 123, second: 1.337});
 
     // apply_if_some_mut only applies the function
     // if the optional contains a value
     
-    let value3 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if_some_mut(Some(100), |builder,val| builder.first(val))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value3, Value{first: 100, second: 1.337});
+    assert_eq!(value, Value{first: 100, second: 1.337});
 
-    let value3 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if_some_mut(None, |builder,val| builder.first(val))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value3, Value{first: 123, second: 1.337});
+    assert_eq!(value, Value{first: 123, second: 1.337});
 }
 ```
 
@@ -89,35 +89,35 @@ struct Value{
 fn main () {
     // apply_if_mut only applies the function
     // if the condition is true
-    let value1 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if(true, |builder| builder.first(100))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value1, Value{first: 100, second: 1.337});
+    assert_eq!(value, Value{first: 100, second: 1.337});
 
-    let value2 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if(false, |builder| builder.first(100))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value2, Value{first: 123, second: 1.337});
+    assert_eq!(value, Value{first: 123, second: 1.337});
 
     // apply_if_some_mut only applies the function
     // if the optional contains a value
     
-    let value3 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if_some(Some(100), |builder,val| builder.first(val))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value3, Value{first: 100, second: 1.337});
+    assert_eq!(value, Value{first: 100, second: 1.337});
 
-    let value3 = ValueBuilder::default()
+    let value = ValueBuilder::default()
         .apply_if_some(None, |builder,val| builder.first(val))
         .second(1.337)
         .build()
         .unwrap();
-    assert_eq!(value3, Value{first: 123, second: 1.337});
+    assert_eq!(value, Value{first: 123, second: 1.337});
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ the nice chaining syntax.
 
 # Examples
 
-This example uses the [`derive_builder`](https://crates.io/crates/derive_builder)
-crate to derive a builder and then uses the `apply_if_...` functions to show
-how to conditionally invoke builder functions without breaking the chain.
+These examples use the [`derive_builder`](https://crates.io/crates/derive_builder)
+crate to create a builder and show how to use the `apply_if...` functions to
+conditionally invoke builder functions without breaking the chain.
 
 ## Mutable Builders
 
@@ -87,7 +87,7 @@ struct Value{
 }
 
 fn main () {
-    // apply_if_mut only applies the function
+    // apply_if only applies the function
     // if the condition is true
     let value = ValueBuilder::default()
         .apply_if(true, |builder| builder.first(100))
@@ -103,9 +103,8 @@ fn main () {
         .unwrap();
     assert_eq!(value, Value{first: 123, second: 1.337});
 
-    // apply_if_some_mut only applies the function
+    // apply_if_some only applies the function
     // if the optional contains a value
-    
     let value = ValueBuilder::default()
         .apply_if_some(Some(100), |builder,val| builder.first(val))
         .second(1.337)

--- a/src/test.rs
+++ b/src/test.rs
@@ -56,6 +56,20 @@ fn test_mutable_builder() {
             .build(),
         (0, 2)
     );
+    assert_eq!(
+        MutableBuilder::default()
+            .apply_if_some_mut(Some(100), |this, n| this.first(n))
+            .second(2)
+            .build(),
+        (100, 2)
+    );
+    assert_eq!(
+        MutableBuilder::default()
+            .apply_if_some_mut(None, |this, n| this.first(n))
+            .second(2)
+            .build(),
+        (0, 2)
+    );
 }
 
 #[test]
@@ -75,6 +89,20 @@ fn test_immutable_builder() {
     assert_eq!(
         ImmutableBuilder::default()
             .apply_if(false, |b| b.first(1))
+            .second(2)
+            .build(),
+        (0, 2)
+    );
+    assert_eq!(
+        ImmutableBuilder::default()
+            .apply_if_some(Some(100), |this, n| this.first(n))
+            .second(2)
+            .build(),
+        (100, 2)
+    );
+    assert_eq!(
+        ImmutableBuilder::default()
+            .apply_if_some(None, |this, n| this.first(n))
             .second(2)
             .build(),
         (0, 2)


### PR DESCRIPTION
Hi Ben, 

I am a happy user of this crate, but I ran into a problem at work when using the crate and wondered if you were open to including my additions. The main changes are:

* relaxed requirements for the closures in `apply_if_...` functions. They used to be bounded on `Fn`, which is stricter than they need to be. I now bounded them on `FnOnce`.
* I added two new functions `apply_if_some` and the mutable counterpart `apply_if_some_mut`, which allow us to conditionally invoke builder functions based on the contents of an optional. Note that this allows us to work with `Option` but also `Result` values (via `.ok()`) and `.err()`, which is why I felt we wouldn't need `apply_if_ok` and `apply_if_err` variants.
* I updated the documentation. The readme now has examples and is also included into the `lib.rs`. This has the advantage that there's only one place for the docs and that the readme is checked during the doc tests. It will not go out of sync with the crate.

Please let me know if you're open to merging those changes in. They would be super useful to me.